### PR TITLE
Use python-telegram-bot to make Telegram API requests

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,18 +5,19 @@ This script simply takes a twitter user name, and fetches the latest tweets
 from their timeline. Then reposts those tweets to a telegram channel(via a bot)
 
 #### Requirements:
-You need Twython installed. Twython is a twitter-python API
+You need Twython installed. Twython is a twitter-python API.
+You also need to install the [`python-telegram-bot`](https://python-telegram-bot.org/) package for making requests to the Telegram API.
 
 #### Notes:
 
 Just create a Telegram Bot(takes only seconds) and add your new bot as an
 administrator to your Channel.
 
-Edit the 'SETTINGS.py' file and update it with your own information.
+Edit the `SETTINGS.py` file and update it with your own information.
 
-The script makes a "pickled" file that holds the tweet ID of the latest tweet it 
+The script makes a "pickled" file that holds the tweet ID of the latest tweet it
 recieved. That way, we can compare the tweet ID later, and make sure that we
 only get the newest tweets, since last time we ran the script.
 
-You can schedule the script to run with something like using cron jobs, 
+You can schedule the script to run with something like using cron jobs,
 every 10 min for example. I run mine at every 5 min for my current bot.

--- a/twitterSays.py
+++ b/twitterSays.py
@@ -1,10 +1,11 @@
 import os, time
 import pickle as pickle
 import twython as Twython
-from urllib.parse import quote
+from telegram import Bot
 from SETTINGS import *
 
 api = Twython.Twython(APP_KEY, APP_SECRET, OAUTH_TOKEN, OAUTH_TOKEN_SECRET)
+bot = Bot(telegram_token)
 latest_tweet_id = 0
 
 def first_run():
@@ -22,17 +23,16 @@ def read_latest_id():
         return 0
     else:
         return line
+
 def send_message(msg):
-    msg = quote(msg, safe='')
-    link = 'https://api.telegram.org/bot'+telegram_token+'/sendMessage?chat_id=@'+channel_name+'\&text="' + msg + '"'
-    os.system('curl '+ link)
-   
+    bot.send_message(chat_id=channel_name, text=msg)
+
 def file_pickle(var):
     pickle.dump(var, open("sav.p", "wb"))
 def file_unpickle():
     saved = pickle.load(open('sav.p', "rb"))
     return saved
- 
+
 def main():
     latest_tweet_id = read_latest_id()
     user_timeline = get_timeline(latest_tweet_id)


### PR DESCRIPTION
instead of a system call to `curl`, which doesn't exist on Windows. It's also just much cleaner to do it like this.